### PR TITLE
Add margin to private label

### DIFF
--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -12,3 +12,7 @@
 	position: static;
 	color: inherit;
 }
+
+:root .repohead h1 .Label {
+    margin-right: 8px;
+}


### PR DESCRIPTION
This gives the build status icon some breathing space

Closes #2681

## Before

<img width="355" alt="Screenshot 2020-01-09 at 10 58 20" src="https://user-images.githubusercontent.com/440503/72062491-cef4f300-32cf-11ea-9e5d-fbfd23b347fb.png">

## After

<img width="359" alt="Screenshot 2020-01-09 at 11 03 59" src="https://user-images.githubusercontent.com/440503/72062504-d4ead400-32cf-11ea-881d-86067d1f86a1.png">
